### PR TITLE
Parse RSS feed for blog posts

### DIFF
--- a/src/components/Blog.js
+++ b/src/components/Blog.js
@@ -1,9 +1,17 @@
 import React, { Component } from "react";
+import DataService from "../services/data";
 
 class Blog extends Component {
+  state = {
+    articles: []
+  };
+
+  async componentDidMount() {
+    const articles = await new DataService().parseRSSFeed();
+    this.setState({ articles });
+  }
 
   renderArticles = (articles) => {
-
     return articles.slice(0, 6).map((article, index) => {
       const date = new Date(article.pubDate);
       var options = { year: 'numeric', month: 'long', day: 'numeric' };
@@ -14,9 +22,9 @@ class Blog extends Component {
             <div className="post-header">
               <ul className="post-meta">
                 <li className="post-date">{date.toLocaleDateString("en-US", options)}</li>
-                <li className="post-date">{article.categories.includes("en")?"English":"Turkish"}</li>
               </ul>
               <h2 className="post-title h5"><a href={article.link} target="_blank" rel="noopener noreferrer" className="hover">{article.title}</a></h2>
+              <p>{article.description}...</p>
             </div>
           </article>
         </div>)
@@ -24,8 +32,7 @@ class Blog extends Component {
   }
 
   render() {
-    const articles = this.props.articles;
-    const url = this.props.url;
+    const { articles } = this.state;
     return (<div className="card">
       <div className="card-header">
         <div className="row gx-0">
@@ -39,7 +46,7 @@ class Blog extends Component {
           {this.renderArticles(articles)}
         </div>
         <div className="row gx-md-25 gy-15 isotope text-right mr-5 mt-5">
-          <a className="btn text-right pr-5" href={url} target="_blank" rel="noopener noreferrer">All blog posts</a>
+          <a className="btn text-right pr-5" href="https://www.minepla.net" target="_blank" rel="noopener noreferrer">All blog posts</a>
         </div>
       </div>
     </div>);

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-
+import xml2js from 'xml2js';
 
 export default class DataService {
 
@@ -11,16 +11,21 @@ export default class DataService {
     static MY_BLOG = "https://www.minepla.net";
     static MY_LINKEDIN_PAGE = "https://www.linkedin.com/in/ardacetinkaya/";
 
-    getBlogPosts = async (rssURL) => {
-        var posts = [];
-        if (rssURL) {
-            posts = axios.get(`https://api.rss2json.com/v1/api.json?rss_url=${rssURL}`)
-                .then(res => {
-                    var posts = res.data.items;
-                    return posts;
-                });
+    parseRSSFeed = async () => {
+        const feedUrl = "https://www.minepla.net/feed/";
+        try {
+            const response = await axios.get(feedUrl);
+            const feed = await xml2js.parseStringPromise(response.data, {trim: true, explicitArray: false});
+            return feed.rss.channel.item.map(item => ({
+                title: item.title,
+                description: item.description.substring(0, 140),
+                link: item.link,
+                pubDate: item.pubDate
+            }));
+        } catch (error) {
+            console.error("Error fetching or parsing RSS feed:", error);
+            return [];
         }
-        return posts;
     }
 
     getSocial = async () => {
@@ -254,4 +259,3 @@ Mostly I work with Microsoft technology stack; <strong>.NET Platform, Azure...et
         ]
     }
 }
-


### PR DESCRIPTION
Related to #1

Implements a new method to fetch and parse RSS feed data for blog posts and updates the Blog component to display these posts.

- Adds a new method `parseRSSFeed` in `src/services/data.js` that:
  - Fetches the RSS feed from "https://www.minepla.net/feed/" using `axios`.
  - Parses the fetched XML data into JSON using `xml2js`.
  - Extracts and formats the blog title and the first 140 characters of the description for each post.
  - Returns a JSON structure containing the parsed and formatted data.

- Updates the `Blog` component in `src/components/Blog.js` to:
  - Use the `parseRSSFeed` method from `DataService` to fetch blog posts on component mount.
  - Render the fetched blog posts, displaying the blog title and the first 140 characters of the description for each post.
  - Remove the previous props-based approach for passing articles to the component, making it self-sufficient in fetching and displaying blog posts.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ardacetinkaya/ardacetinkaya.github.io/issues/1?shareId=09057762-406c-4f0f-a971-f4659c499b78).